### PR TITLE
Add Kubernetes Poller and Image Resolver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'
 	implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+	implementation 'io.kubernetes:client-java:4.0.0'
 	runtimeOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/kotlin/wintertechforum/trackingcommits/docker/DockerImageSpec.kt
+++ b/src/main/kotlin/wintertechforum/trackingcommits/docker/DockerImageSpec.kt
@@ -1,0 +1,6 @@
+package wintertechforum.trackingcommits.docker
+
+data class DockerImageSpec(
+    val imageRepo: String,
+    val imageId: String
+)

--- a/src/main/kotlin/wintertechforum/trackingcommits/k8s/KubernetesClusterConfiguration.kt
+++ b/src/main/kotlin/wintertechforum/trackingcommits/k8s/KubernetesClusterConfiguration.kt
@@ -1,0 +1,6 @@
+package wintertechforum.trackingcommits.k8s
+
+data class KubernetesClusterConfiguration(
+    val clusterName: String,
+    val namespace: String
+)

--- a/src/main/kotlin/wintertechforum/trackingcommits/k8s/KubernetesImageResolver.kt
+++ b/src/main/kotlin/wintertechforum/trackingcommits/k8s/KubernetesImageResolver.kt
@@ -1,0 +1,31 @@
+package wintertechforum.trackingcommits.k8s
+
+import io.kubernetes.client.apis.CoreV1Api
+import io.kubernetes.client.util.Config
+import wintertechforum.trackingcommits.docker.DockerImageSpec
+
+class KubernetesImageResolver(
+    val config: KubernetesClusterConfiguration
+) {
+  private val client = Config.defaultClient()
+
+  fun listServerGroupImages(serverGroup: KubernetesServerGroup) =
+      CoreV1Api(client).listNamespacedPod(
+          config.namespace,
+          null,
+          null,
+          null,
+          null,
+          serverGroup.selectorMatchLabels.map { (key, value) -> "$key=$value" }.joinToString(","),
+          null,
+          null,
+          null,
+          null
+      ).items.flatMap { it.status.containerStatuses }.map {
+        DockerImageSpec(
+            it.image,
+            it.imageID
+        )
+      }.distinct()
+}
+

--- a/src/main/kotlin/wintertechforum/trackingcommits/k8s/KubernetesPoller.kt
+++ b/src/main/kotlin/wintertechforum/trackingcommits/k8s/KubernetesPoller.kt
@@ -1,0 +1,75 @@
+package wintertechforum.trackingcommits.k8s
+
+import io.kubernetes.client.apis.AppsV1Api
+import io.kubernetes.client.util.Config
+
+
+class KubernetesPoller(
+    private val config: KubernetesClusterConfiguration
+) {
+  private val client = Config.defaultClient()
+
+  fun listDeployments(): List<KubernetesServerGroup> = AppsV1Api(client).listNamespacedDeployment(
+      config.namespace,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+  ).items.map {
+    KubernetesServerGroup(
+        config,
+        KubernetesServerGroup.ServerGroupType.DEPLOYMENT,
+        it.metadata.name,
+        it.metadata.labels ?: emptyMap(),
+        it.spec.selector.matchLabels,
+        it.metadata.generation
+    )
+  }
+
+  fun listStatefulSets(): List<KubernetesServerGroup> = AppsV1Api(client).listNamespacedStatefulSet(
+      config.namespace,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+  ).items.map {
+    KubernetesServerGroup(
+        config,
+        KubernetesServerGroup.ServerGroupType.STATEFUL_SET,
+        it.metadata.name,
+        it.metadata.labels ?: emptyMap(),
+        it.spec.selector.matchLabels,
+        it.metadata.generation
+    )
+  }
+}
+
+// Make this main to play with the kubernetes poller and resolver
+fun notMain() {
+  val config = KubernetesClusterConfiguration(
+      "minikube",
+      "default"
+  )
+  val poller = KubernetesPoller(
+      config
+  )
+  val resolver = KubernetesImageResolver(
+      config
+  )
+  (poller.listDeployments() + poller.listStatefulSets()).forEach {
+    println(it)
+    resolver.listServerGroupImages(it).forEach {
+      println("> $it")
+    }
+  }
+}

--- a/src/main/kotlin/wintertechforum/trackingcommits/k8s/KubernetesServerGroup.kt
+++ b/src/main/kotlin/wintertechforum/trackingcommits/k8s/KubernetesServerGroup.kt
@@ -1,0 +1,14 @@
+package wintertechforum.trackingcommits.k8s
+
+data class KubernetesServerGroup(
+    val config: KubernetesClusterConfiguration,
+    val resourceType: ServerGroupType,
+    val resourceName: String,
+    val resourceLabels: Map<String, String>,
+    val selectorMatchLabels: Map<String, String>,
+    val generation: Long
+){
+  enum class ServerGroupType {
+    DEPLOYMENT, STATEFUL_SET
+  }
+}


### PR DESCRIPTION
Simple poller and image resolver with interacts with the a Kubernetes cluster. Treats both Deployments and StatefulSets as ServerGroups. Obtains the image tag and ID from the pod.